### PR TITLE
Updating ShootPoint arguments

### DIFF
--- a/aslm/core.py
+++ b/aslm/core.py
@@ -1,11 +1,12 @@
 import os
+import os.path as op
 import re
 import subprocess
 
 import numpy as np
 # import pandas as pd
 
-from .utils import log_run
+from .utils import log_run, get_file_name
 
 
 def run_MD(inputfile, jobname, logfile=None, topology="system.prmtop",
@@ -58,12 +59,18 @@ def find_and_replace(line, substitutions):
 
 
 class ShootingPoint:
-    def __init__(self):
-        self.name = None  # Name of shooting point
+    def __init__(self, name, input_file, topology_file=None,
+                 md_engine="AMBER"):
+        self.name = name  # Name of shooting point
+        self.input_file = input_file  # Path to input file (e.g., `init.in`)
+        self.topology_file = topology_file  # Path to topology file
+        self.md_engine = md_engine
+        self._input_file_dir = op.dirname(op.abspath(self.input_file))
+        self._input_file_name = op.splitext(op.basename(self.input_file))[0]
+
         self.forward_commit = None  # Status of forward simulation
         self.reverse_commit = None  # Status of reverse simulation
         self.result = None  # Result of shooting point
-        self.path = None
         self.cv_values = None
         return
 
@@ -79,7 +86,7 @@ class ShootingPoint:
         """
         jobname = self.name + "_f"
         logfile = self.name + "_f.log"
-        run_MD(inputfile, jobname, logfile, topology="system.prmtop",
+        run_MD(self.input_file, jobname, logfile, topology="system.prmtop",
                engine="AMBER")
         self.forward_commit = self.check_if_committed(logfile)
         return

--- a/aslm/core.py
+++ b/aslm/core.py
@@ -4,9 +4,8 @@ import re
 import subprocess
 
 import numpy as np
-# import pandas as pd
 
-from .utils import log_run, get_file_name
+from .utils import log_run
 
 
 def run_MD(inputfile, jobname, logfile=None, topology="system.prmtop",

--- a/aslm/tests/test_core.py
+++ b/aslm/tests/test_core.py
@@ -10,7 +10,7 @@ from ..core import ShootingPoint, find_and_replace
 def test_read_cv_values():
     test_file_loc = op.join(op.dirname(op.abspath(__file__)),
                             'test_data', 'COLVAR2')
-    sp = ShootingPoint()
+    sp = ShootingPoint(name='test', input_file='.')
 
     sp._read_cv_values(test_file_loc)
     test_values = sp.cv_values
@@ -29,7 +29,7 @@ def test_find_and_replace():
 
 
 def test_check_if_commited():
-    sp = ShootingPoint()
+    sp = ShootingPoint(name='test', input_file='.')
     test_file_loc = op.join(op.dirname(op.abspath(__file__)),
                             'test_data', 'commit.log')
     test_result = sp.check_if_committed(test_file_loc)
@@ -43,7 +43,7 @@ def test_check_if_commited():
 
 
 def test_log():
-    sp = ShootingPoint()
+    sp = ShootingPoint(name='test', input_file='.')
     sp.name = 'test'
     sp.cv_values = [1, 2, 3]
     sp.result = 'accepted'


### PR DESCRIPTION
With this PR, a `ShootingPoint` now requires the name of the shooting point, the location of the master input file, and the name of the MD engine (default=AMBER).